### PR TITLE
Exclude tests from installed packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 setup(
     name="wraptools",
     version="1.1",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     author="Hiroki Kiyohara",
     author_email="hirokiky@gmail.com",
     description="Utilities for wrapping and dispatching functions",


### PR DESCRIPTION
Hi.  @hirokiky.

Your test codes were installed as top level package.
I've fixed to exclude them. Because no one is happy.

```
(venv) $ pip install wraptools
(venv) $ tree -L 1 venv/lib/python3.6/site-packages/tests/
venv/lib/python3.6/site-packages/tests/
├── __init__.py
├── __pycache__
├── test_context.py 
├── test_dispatch.py
└── test_pluggable.py
```

See also https://packaging.python.org/tutorials/distributing-packages/#packages.
thx :)